### PR TITLE
Run SolrRddSpark and HdfsSpark on Himrod

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,56 @@ python3 collect_driver_metrics.py <seq/solr/spark> <search term> <sleep time in 
 
 - Installing Kubernetes via Kubespray: https://github.com/kubernetes-sigs/kubespray
 - HDFS on Kubernetes: https://github.com/apache-spark-on-k8s/kubernetes-HDFS
+
+--
+
+## Running on Himrod
+
+- Add necessary destinations to your path each time you start a session
+```
+export PATH="$PATH:/localdisk5/hadoop/hadoop/bin:/localdisk5/hadoop/hadoop/sbin"
+export PATH="$PATH:/localdisk5/hadoop/spark/bin"
+
+export JAVA_HOME=/usr/lib/jvm/java-8-oracle/jre
+export HADOOP_CONF_DIR=/localdisk5/hadoop/hadoop/etc/hadoop
+export SPARK_HOME=/localdisk5/hadoop/spark
+export LD_LIBRARY_PATH=/localdisk5/hadoop/hadoop/lib/native:$LD_LIBRARY_PATH
+```
+
+TODO: try changing number of executors for ParalellDocIdSpark and SolrRddSpark too
+
+- ParallelDocIdSpark
+```
+spark-submit \
+    --deploy-mode client \
+    --name sent-detector-solr-spark \
+    --class ca.uwaterloo.SIGIR.ParallelDocIdSpark \
+    target/cs848-project-1.0-SNAPSHOT.jar \
+    --term <term> \
+    --field raw \
+    --solr 192.168.1.111:9983 \
+    --index gov2
+```
+
+- HdfsSpark
+```
+spark-submit \
+    --deploy-mode client \
+    --name sent-detector-hdfs-spark \
+    --class ca.uwaterloo.SIGIR.HdfsSpark \
+   --conf spark.executor.instances=10 \
+    target/cs848-project-1.0-SNAPSHOT.jar \
+    --term <term> \
+    --path /collections/gov2
+```
+
+- HdfsSpark
+```
+spark-submit \
+    --deploy-mode client \
+    --name sent-detector-hdfs-spark \
+    --class ca.uwaterloo.SIGIR.HdfsSpark \
+    target/cs848-project-1.0-SNAPSHOT.jar \
+    --term Interpol \
+    --path /collections/gov2
+```

--- a/pom.xml
+++ b/pom.xml
@@ -171,38 +171,38 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.1.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <createDependencyReducedPom>false</createDependencyReducedPom>
-              <!-- This is an Mac OSX issue because the default filesystem is case-insensitive,
-                   so multiple versions of files (w/ different cases) clash when Hadoop tries
-                   to unpack the jar. -->
-              <filters>
-                <filter>
-                  <artifact>*:*</artifact>
-                  <excludes>
-                    <exclude>META-INF/*.SF</exclude>
-                    <exclude>META-INF/*.DSA</exclude>
-                    <exclude>META-INF/*.RSA</exclude>
-                    <exclude>META-INF/LICENSE*</exclude>
-                    <exclude>license/*</exclude>
-                  </excludes>
-                </filter>
-              </filters>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-shade-plugin</artifactId>-->
+        <!--<version>3.1.0</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<phase>package</phase>-->
+            <!--<goals>-->
+              <!--<goal>shade</goal>-->
+            <!--</goals>-->
+            <!--<configuration>-->
+              <!--<shadedArtifactAttached>true</shadedArtifactAttached>-->
+              <!--<createDependencyReducedPom>false</createDependencyReducedPom>-->
+              <!--&lt;!&ndash; This is an Mac OSX issue because the default filesystem is case-insensitive,-->
+                   <!--so multiple versions of files (w/ different cases) clash when Hadoop tries-->
+                   <!--to unpack the jar. &ndash;&gt;-->
+              <!--<filters>-->
+                <!--<filter>-->
+                  <!--<artifact>*:*</artifact>-->
+                  <!--<excludes>-->
+                    <!--<exclude>META-INF/*.SF</exclude>-->
+                    <!--<exclude>META-INF/*.DSA</exclude>-->
+                    <!--<exclude>META-INF/*.RSA</exclude>-->
+                    <!--<exclude>META-INF/LICENSE*</exclude>-->
+                    <!--<exclude>license/*</exclude>-->
+                  <!--</excludes>-->
+                <!--</filter>-->
+              <!--</filters>-->
+            <!--</configuration>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -171,38 +171,38 @@
         </configuration>
       </plugin>
 
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-shade-plugin</artifactId>-->
-        <!--<version>3.1.0</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<phase>package</phase>-->
-            <!--<goals>-->
-              <!--<goal>shade</goal>-->
-            <!--</goals>-->
-            <!--<configuration>-->
-              <!--<shadedArtifactAttached>true</shadedArtifactAttached>-->
-              <!--<createDependencyReducedPom>false</createDependencyReducedPom>-->
-              <!--&lt;!&ndash; This is an Mac OSX issue because the default filesystem is case-insensitive,-->
-                   <!--so multiple versions of files (w/ different cases) clash when Hadoop tries-->
-                   <!--to unpack the jar. &ndash;&gt;-->
-              <!--<filters>-->
-                <!--<filter>-->
-                  <!--<artifact>*:*</artifact>-->
-                  <!--<excludes>-->
-                    <!--<exclude>META-INF/*.SF</exclude>-->
-                    <!--<exclude>META-INF/*.DSA</exclude>-->
-                    <!--<exclude>META-INF/*.RSA</exclude>-->
-                    <!--<exclude>META-INF/LICENSE*</exclude>-->
-                    <!--<exclude>license/*</exclude>-->
-                  <!--</excludes>-->
-                <!--</filter>-->
-              <!--</filters>-->
-            <!--</configuration>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <!-- This is an Mac OSX issue because the default filesystem is case-insensitive,
+                   so multiple versions of files (w/ different cases) clash when Hadoop tries
+                   to unpack the jar. -->
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/*.SF</exclude>
+                    <exclude>META-INF/*.DSA</exclude>
+                    <exclude>META-INF/*.RSA</exclude>
+                    <exclude>META-INF/LICENSE*</exclude>
+                    <exclude>license/*</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
               <goal>shade</goal>
             </goals>
             <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
               <createDependencyReducedPom>false</createDependencyReducedPom>
               <!-- This is an Mac OSX issue because the default filesystem is case-insensitive,
                    so multiple versions of files (w/ different cases) clash when Hadoop tries

--- a/src/main/scala/ca/uwaterloo/SIGIR/HdfsSpark.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/HdfsSpark.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.cs848
+package ca.uwaterloo.SIGIR
 
 import ca.uwaterloo.cs848.conf.HdfsConf
 import ca.uwaterloo.cs848.util.{SentenceDetector, Stemmer}

--- a/src/main/scala/ca/uwaterloo/SIGIR/HdfsSpark.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/HdfsSpark.scala
@@ -10,7 +10,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 object HdfsSpark {
 
   val log = Logger.getLogger(getClass.getName)
-  PropertyConfigurator.configure("/hdd1/CS848-project/log4j.properties")
+  PropertyConfigurator.configure("/localdisk0/etc/log4j.properties")
 
   def main(argv: Array[String]) = {
 

--- a/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
@@ -9,7 +9,7 @@ import org.apache.spark.{SparkConf, SparkContext}
 object SolrSpark {
 
   val log = Logger.getLogger(getClass.getName)
-  PropertyConfigurator.configure("/hdd1/CS848-project/log4j.properties")
+  PropertyConfigurator.configure("/localdisk0/etc/log4j.properties")
 
   def main(argv: Array[String]) = {
 

--- a/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.cs848
+package ca.uwaterloo.SIGIR
 
 import ca.uwaterloo.cs848.conf.SolrConf
 import ca.uwaterloo.cs848.util.SentenceDetector

--- a/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/SolrRddSpark.scala
@@ -6,7 +6,7 @@ import com.lucidworks.spark.rdd.SelectSolrRDD
 import org.apache.log4j.{Logger, PropertyConfigurator}
 import org.apache.spark.{SparkConf, SparkContext}
 
-object SolrSpark {
+object SolrRddSpark {
 
   val log = Logger.getLogger(getClass.getName)
   PropertyConfigurator.configure("/localdisk0/etc/log4j.properties")

--- a/src/main/scala/ca/uwaterloo/SIGIR/conf/HdfsConf.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/conf/HdfsConf.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.cs848.conf
+package ca.uwaterloo.SIGIR
 
 import org.rogach.scallop.ScallopConf
 

--- a/src/main/scala/ca/uwaterloo/SIGIR/conf/HdfsConf.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/conf/HdfsConf.scala
@@ -1,0 +1,15 @@
+package ca.uwaterloo.cs848.conf
+
+import org.rogach.scallop.ScallopConf
+
+class HdfsConf(args: Seq[String]) extends ScallopConf(args) {
+
+  mainOptions = Seq(term, path)
+
+  val term = opt[String](descr = "search term", required = true)
+  val path = opt[String](descr = "hdfs path", required = true)
+  val debug = opt[Boolean](descr = "debug / print")
+
+  verify()
+
+}

--- a/src/main/scala/ca/uwaterloo/SIGIR/conf/SolrConf.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/conf/SolrConf.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.cs848.conf
+package ca.uwaterloo.SIGIR
 
 import org.rogach.scallop.ScallopConf
 

--- a/src/main/scala/ca/uwaterloo/SIGIR/conf/SolrConf.scala
+++ b/src/main/scala/ca/uwaterloo/SIGIR/conf/SolrConf.scala
@@ -1,0 +1,24 @@
+package ca.uwaterloo.cs848.conf
+
+import org.rogach.scallop.ScallopConf
+
+class SolrConf(args: Seq[String]) extends ScallopConf(args) {
+
+  mainOptions = Seq(term, field, solr, index, debug)
+
+  val field = opt[String](descr = "search field", required = true)
+  val term = opt[String](descr = "search term", required = true)
+
+  val solr = opt[String](descr = "Solr base URLs", required = true)
+  val index = opt[String](descr = "Solr index name", required = true)
+
+  val rows = opt[Int](descr = "number of rows to return per request", default = Some(1000))
+  val parallelism = opt[Int](descr = "number of cores/executors/etc. to use", default = Some(12))
+
+  val debug = opt[Boolean](descr = "debug / print")
+
+  codependent(field, term, solr, index)
+
+  verify()
+
+}

--- a/src/main/scala/ca/uwaterloo/cs848/HdfsSpark.scala
+++ b/src/main/scala/ca/uwaterloo/cs848/HdfsSpark.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.SIGIR
+package ca.uwaterloo.cs848
 
 import ca.uwaterloo.cs848.conf.HdfsConf
 import ca.uwaterloo.cs848.util.{SentenceDetector, Stemmer}

--- a/src/main/scala/ca/uwaterloo/cs848/Solr.scala
+++ b/src/main/scala/ca/uwaterloo/cs848/Solr.scala
@@ -19,7 +19,7 @@ object Solr {
   val MILLIS_IN_DAY = 1000 * 60 * 60 * 24
 
   val log = Logger.getLogger(getClass.getName)
-  PropertyConfigurator.configure("/localdisk0/etc/log4j.properties")
+  PropertyConfigurator.configure("/hdd1/CS848-project/log4j.properties")
 
   def main(argv: Array[String]) = {
 

--- a/src/main/scala/ca/uwaterloo/cs848/SolrSpark.scala
+++ b/src/main/scala/ca/uwaterloo/cs848/SolrSpark.scala
@@ -1,4 +1,4 @@
-package ca.uwaterloo.SIGIR
+package ca.uwaterloo.cs848
 
 import ca.uwaterloo.cs848.conf.SolrConf
 import ca.uwaterloo.cs848.util.SentenceDetector
@@ -6,7 +6,7 @@ import com.lucidworks.spark.rdd.SelectSolrRDD
 import org.apache.log4j.{Logger, PropertyConfigurator}
 import org.apache.spark.{SparkConf, SparkContext}
 
-object SolrSpark {
+object SolrRddSpark {
 
   val log = Logger.getLogger(getClass.getName)
   PropertyConfigurator.configure("/hdd1/CS848-project/log4j.properties")


### PR DESCRIPTION
Both experiments now successfully run on the new cluster.

I specified the number of executors for HdfsSpark because it was painfully slow otherwise. I'll make it consistent across all experiments in the next commit.

For reference, with "idea" as the search term, HdfsSpark took ~1.5 hours while SolrRddSpark took ~0.9. I'll run both for all search terms, and investigate why both (at least for "idea") are actually slower than on Tembo.